### PR TITLE
Remove users from Github that are suspended in Google

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ updates:
 | `GOOGLE_CREDENTIALS`     | Base64'd json as downloaded from the google service account creation step                                                       | `Zm9vCg==`        | `null`  |
 | `ADD_USERS`              | Set to TRUE to add users to the github organisation                                                                             | `TRUE`            | `false` |
 | `REMOVE_USERS`           | Set to TRUE to remove users from the github organisation                                                                        | `TRUE`            | `false` |
+| `REMOVE_SUSPENDED_USERS` | Set to TRUE to remove users from the github organisation that are suspended in Google                                           | `TRUE`            | `false` |
 | `EXIT_CODE_ON_MISMATCH`  | Exit code to use when there's a mismatch, useful when combined with `ADD_USERS` and `REMOVE_USERS` to be used in a dry-run mode | `1`               | `0`     |
 | `GITHUB_ORG`             | GitHub Organization                                                                                                             | `chrisnstest`     | `null`  |
 | `GITHUB_APP_ID`          | GitHub App ID                                                                                                                   | `106341`          | `null`  |

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,6 +32,9 @@ export const config = {
   get googleEmailAddress(): string {
     return process.env.GOOGLE_EMAIL_ADDRESS ?? ''
   },
+  get removeSuspendedUsers(): boolean {
+    return process.env.REMOVE_SUSPENDED_USERS?.toLowerCase() === 'true'
+  },
 }
 
 export interface googleCredentials {

--- a/src/google.ts
+++ b/src/google.ts
@@ -37,6 +37,7 @@ export async function getGithubUsersFromGoogle(): Promise<Set<string>> {
       fields: 'users(customSchemas/Accounts/github(value)),nextPageToken',
       customFieldMask: 'Accounts',
       pageToken: pageToken,
+      query: config.removeSuspendedUsers ? 'isSuspended=false' : '',
     })
     pageToken = userList.data.nextPageToken
     githubAccounts = new Set([...githubAccounts, ...formatUserList(userList.data.users)])

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -156,3 +156,28 @@ describe('googleEmailAddress', () => {
     expect(mod.config.googleEmailAddress).toStrictEqual('hello')
   })
 })
+
+describe('removeSuspendedUsers', () => {
+  beforeEach(() => {
+    delete process.env.REMOVE_SUSPENDED_USERS
+  })
+  it('no value', () => {
+    expect(mod.config.removeSuspendedUsers).toStrictEqual(false)
+  })
+  it('invalid value', () => {
+    process.env.REMOVE_SUSPENDED_USERS = 'foobar'
+    expect(mod.config.removeSuspendedUsers).toStrictEqual(false)
+  })
+  it('false value', () => {
+    process.env.REMOVE_SUSPENDED_USERS = 'false'
+    expect(mod.config.removeSuspendedUsers).toStrictEqual(false)
+  })
+  it('true value', () => {
+    process.env.REMOVE_SUSPENDED_USERS = 'true'
+    expect(mod.config.removeSuspendedUsers).toStrictEqual(true)
+  })
+  it('true value mixed case', () => {
+    process.env.REMOVE_SUSPENDED_USERS = 'tRuE'
+    expect(mod.config.removeSuspendedUsers).toStrictEqual(true)
+  })
+})


### PR DESCRIPTION
Made it possible to remove suspended users in Google from Github.
The environment variable "REMOVE_SUSPENDED_USERS" controls this, which is "false" by default for backward compatibility.