### PR TITLE
chore(build): correct labling from v1 to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           tag-latest: true
           tag-semver: |
             {{version}}
-          label-custom: |
+          labels: |
             org.opencontainers.image.vendor=reMarkable
             org.opencontainers.image.documentation=https://github.com/reMarkable/githubUserManager
             org.opencontainers.image.authors=Marcus Ramberg <marcus.ramberg@remarkable.com>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,9 @@ jobs:
         uses: docker/metadata-action@dbef88086f6cef02e264edb7dbf63250c17cef6c # v5.5.0
         with:
           images: docker.pkg.github.com/remarkable/githubUserManager/githubUserManager
-          tag-sha: true
-          tag-latest: true
-          tag-semver: |
-            {{version}}
+          tags: |
+            type=sha
+            type=semver,pattern={{version}}
           labels: |
             org.opencontainers.image.vendor=reMarkable
             org.opencontainers.image.documentation=https://github.com/reMarkable/githubUserManager


### PR DESCRIPTION
Tagging has never worked in our repo, and the versioning has been default.
Fixed the config to actually work the way we had intended it to.