### PR TITLE
chore(test): switch from deprecated jest aliases

### DIFF
--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -31,22 +31,22 @@ describe('missmatch', () => {
 
   it('should exit with 0 by default as there is a missmatch', async () => {
     await mod.run()
-    return expect(processExitSpy).toBeCalledWith(0)
+    return expect(processExitSpy).toHaveBeenCalledWith(0)
   })
   it('should exit with 122 if defined when there is a missmatch', async () => {
     process.env.EXIT_CODE_ON_MISMATCH = '122'
     await mod.run()
-    return expect(processExitSpy).toBeCalledWith(122)
+    return expect(processExitSpy).toHaveBeenCalledWith(122)
   })
   it('should not add users if not set to', async () => {
     delete process.env.ADD_USERS
     await mod.run()
-    return expect(github.addUsersToGitHubOrg).not.toBeCalled()
+    return expect(github.addUsersToGitHubOrg).not.toHaveBeenCalled()
   })
   it('should not remove users if not set to', async () => {
     delete process.env.REMOVE_USERS
     await mod.run()
-    return expect(github.removeUsersFromGitHubOrg).not.toBeCalled()
+    return expect(github.removeUsersFromGitHubOrg).not.toHaveBeenCalled()
   })
   it('should add users if set to', async () => {
     process.env.ADD_USERS = 'true'
@@ -79,21 +79,21 @@ describe('match', () => {
   })
   it('should exit with 0 by default', async () => {
     await mod.run()
-    return expect(processExitSpy).toBeCalledWith(0)
+    return expect(processExitSpy).toHaveBeenCalledWith(0)
   })
   it('should not exit with 122 if defined', async () => {
     process.env.EXIT_CODE_ON_MISMATCH = '122'
     await mod.run()
-    return expect(processExitSpy).not.toBeCalledWith(122)
+    return expect(processExitSpy).not.toHaveBeenCalledWith(122)
   })
   it('should not add users', async () => {
     process.env.ADD_USERS = 'true'
     await mod.run()
-    return expect(github.addUsersToGitHubOrg).not.toBeCalled()
+    return expect(github.addUsersToGitHubOrg).not.toHaveBeenCalled()
   })
   it('should not remove users', async () => {
     process.env.REMOVE_USERS = 'true'
     await mod.run()
-    return expect(github.removeUsersFromGitHubOrg).not.toBeCalled()
+    return expect(github.removeUsersFromGitHubOrg).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
in jest v30, [alias matcher functions will be removed](https://jestjs.io/docs/upgrading-to-jest30#removal-of-alias-matcher-functions).
these aliases have been deprecated since jest v26, but we are still using them.
this pr fixes #238